### PR TITLE
Add meh keyword

### DIFF
--- a/src/hotkey.h
+++ b/src/hotkey.h
@@ -49,7 +49,10 @@ enum hotkey_flag
     Hotkey_Flag_Hyper       = (Hotkey_Flag_Cmd |
                                Hotkey_Flag_Alt |
                                Hotkey_Flag_Shift |
-                               Hotkey_Flag_Control)
+                               Hotkey_Flag_Control),
+    Hotkey_Flag_Meh         = (Hotkey_Flag_Control |
+                               Hotkey_Flag_Shift |
+                               Hotkey_Flag_Alt)
 };
 
 #include "hashtable.h"

--- a/src/parse.c
+++ b/src/parse.c
@@ -158,7 +158,7 @@ internal enum hotkey_flag modifier_flags_value[] =
     Hotkey_Flag_Shift,      Hotkey_Flag_LShift,     Hotkey_Flag_RShift,
     Hotkey_Flag_Cmd,        Hotkey_Flag_LCmd,       Hotkey_Flag_RCmd,
     Hotkey_Flag_Control,    Hotkey_Flag_LControl,   Hotkey_Flag_RControl,
-    Hotkey_Flag_Fn,         Hotkey_Flag_Hyper,
+    Hotkey_Flag_Fn,         Hotkey_Flag_Hyper,      Hotkey_Flag_Meh,
 };
 
 internal uint32_t

--- a/src/tokenize.h
+++ b/src/tokenize.h
@@ -7,7 +7,7 @@ static const char *modifier_flags_str[] =
     "shift", "lshift",  "rshift",
     "cmd",   "lcmd",    "rcmd",
     "ctrl",  "lctrl",   "rctrl",
-    "fn",    "hyper",
+    "fn",    "hyper",   "meh",
 };
 
 static const char *literal_keycode_str[] =


### PR DESCRIPTION
This PR adds the "meh" modifier which is a meh version of the hyper modifier. It's supported in QMK keyboard firmware (https://github.com/qmk/qmk_firmware/blob/master/docs/keycodes.md#modifiers) which is used on keyboards such as [ergodox ez](https://ergodox-ez.com).

Example use:

```
# focus window
hyper - left : chunkc tiling::window --focus west
hyper - down : chunkc tiling::window --focus south
hyper - up : chunkc tiling::window --focus north
hyper - right : chunkc tiling::window --focus east

# swap window
meh - left : chunkc tiling::window --swap west
meh - down : chunkc tiling::window --swap south
meh - up : chunkc tiling::window --swap north
meh - right : chunkc tiling::window --swap east
```

Which results in hyper + direction to move focus direction with chunkwm, or the meh + direction to swap window in a direction. That's equivalent to `ctrl + shift + alt + cmd + direction` or `ctrl + shift + alt + direction` respectively.