### PR TITLE
workaround for synthesizing text

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ all: clean $(BINS)
 install: BUILD_FLAGS=-std=c99 -O3
 install: clean $(BINS)
 
-profile: BUILD_FLAGS=-std=c99 -Wall -g -O0 -DSKHD_PROFILE
+profile: BUILD_FLAGS=-std=c99 -Wall -g -O0 -DSKHD_PROFILE -fsanitize=address,undefined -fno-omit-frame-pointer
 profile: clean $(BINS)
 
 fast_profile: BUILD_FLAGS=-std=c99 -O3 -DSKHD_PROFILE

--- a/src/skhd.c
+++ b/src/skhd.c
@@ -128,12 +128,13 @@ internal bool
 parse_arguments(int argc, char **argv)
 {
     int option;
-    const char *short_option = "Vvc:k:t:";
+    const char *short_option = "Vvc:k:a:t:";
     struct option long_option[] = {
         { "verbose", no_argument, NULL, 'V' },
         { "version", no_argument, NULL, 'v' },
         { "config", required_argument, NULL, 'c' },
         { "key", required_argument, NULL, 'k' },
+        { "ascii", required_argument, NULL, 'a' },
         { "text", required_argument, NULL, 't' },
         { NULL, 0, NULL, 0 }
     };
@@ -152,6 +153,10 @@ parse_arguments(int argc, char **argv)
         } break;
         case 'k': {
             synthesize_key(optarg);
+            return true;
+        } break;
+        case 'a': {
+            synthesize_ascii(optarg);
             return true;
         } break;
         case 't': {

--- a/src/synthesize.c
+++ b/src/synthesize.c
@@ -63,6 +63,32 @@ void synthesize_key(char *key_string)
     synthesize_modifiers(hotkey, false);
 }
 
+void synthesize_ascii(char *text){
+  size_t n = strlen(text);
+  for (size_t i = 0; i < n; i++){
+    // take 1 char from ascii text
+    char c[2];
+    memcpy(c, &text[i], 1);
+    c[1] = '\0';
+
+    if (!initialize_keycode_map()) continue;
+    struct parser parser;
+
+    parser_init_text(&parser, c);
+    struct hotkey *hotkey = parse_keypress(&parser);
+    if (!hotkey) continue;
+    CGSetLocalEventsSuppressionInterval(0.0f);
+    CGEnableEventStateCombining(false);
+
+    create_and_post_keyevent(hotkey->key, true);
+    create_and_post_keyevent(hotkey->key, false);
+    usleep(300);
+    free(hotkey);
+  }
+  close(1);
+  close(2);
+}
+
 void synthesize_text(char *text)
 {
     CFStringRef text_ref = CFStringCreateWithCString(NULL, text, kCFStringEncodingUTF8);


### PR DESCRIPTION
#44 mentioned: `# synthesize text - does not work on Mojave (for now..)`

this PR adds option `-a` to simplify configuration of keystroke-sequence, previously:

``` 
ctrl - j : skhd -k "1"; skhd -k "w"; skhd -k "2"; skhd -k "w"; skhd -k "3"; skhd -k "q"; skhd -k "e"; skhd -k "4"; skhd -k "e"; skhd -k "w"; skhd -k "q"
```

new:

```
ctrl - j : skhd -a "1w2w3qe4ewq"
```