### PR TITLE
Fix kitty application path

### DIFF
--- a/examples/skhdrc
+++ b/examples/skhdrc
@@ -106,7 +106,7 @@
 # ]
 
 # open terminal, blazingly fast compared to iTerm/Hyper
-cmd - return : /Applications/Kitty.app/Contents/MacOS/kitty --single-instance -d ~
+cmd - return : /Applications/kitty.app/Contents/MacOS/kitty --single-instance -d ~
 
 # open qutebrowser
 cmd + shift - return : ~/Scripts/qtb.sh


### PR DESCRIPTION
Just a minor capitalization fix for the [kitty](https://sw.kovidgoyal.net/kitty/) application path in the default config: kitty gets installed into `/Applications/kitty.app` (not `/Applications/Kitty.app`) - On a non case-insensitive partition this would break the launcher (it just wouldn't do anything).