### PR TITLE
Add function keys F21-F24

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -168,7 +168,8 @@ internal uint32_t literal_keycode_value[] =
     kVK_F10,        kVK_F11,           kVK_F12,
     kVK_F13,        kVK_F14,           kVK_F15,
     kVK_F16,        kVK_F17,           kVK_F18,
-    kVK_F19,        kVK_F20,
+    kVK_F19,        kVK_F20,           kVK_F21,
+    kVK_F22,        kVK_F23,           kVK_F24,
 
     NX_KEYTYPE_SOUND_UP,        NX_KEYTYPE_SOUND_DOWN,      NX_KEYTYPE_MUTE,
     NX_KEYTYPE_PLAY,            NX_KEYTYPE_PREVIOUS,        NX_KEYTYPE_NEXT,

--- a/src/tokenize.h
+++ b/src/tokenize.h
@@ -25,7 +25,8 @@ global const char *literal_keycode_str[] =
     "f10",             "f11",             "f12",
     "f13",             "f14",             "f15",
     "f16",             "f17",             "f18",
-    "f19",             "f20",
+    "f19",             "f20",             "f21",
+    "f22",             "f23",             "f24",
 
     "sound_up",        "sound_down",      "mute",
     "play",            "previous",        "next",


### PR DESCRIPTION
I have these keys available to me on a Logitech G600 mouse (but they're generally present on a range of keyboards, usually many older types such as the [IBM 3270](https://www.seasip.info/VintagePC/Images/6110344.jpg)). When I try to map function keys higher than F20 it causes _all_ of my configured skhd shortcuts to stop working.