### PR TITLE
Add L/R hypers

### DIFF
--- a/src/hotkey.h
+++ b/src/hotkey.h
@@ -50,6 +50,14 @@ enum hotkey_flag
                                Hotkey_Flag_Alt |
                                Hotkey_Flag_Shift |
                                Hotkey_Flag_Control),
+    Hotkey_Flag_RHyper      = (Hotkey_Flag_RCmd |
+			       Hotkey_Flag_RAlt |
+			       Hotkey_Flag_RShift |
+			       Hotkey_Flag_RControl),
+    Hotkey_Flag_LHyper      = (Hotkey_Flag_LCmd |
+			       Hotkey_Flag_LAlt |
+			       Hotkey_Flag_LShift |
+			       Hotkey_Flag_LControl),
     Hotkey_Flag_Meh         = (Hotkey_Flag_Control |
                                Hotkey_Flag_Shift |
                                Hotkey_Flag_Alt)

--- a/src/parse.c
+++ b/src/parse.c
@@ -207,7 +207,8 @@ internal enum hotkey_flag modifier_flags_value[] =
     Hotkey_Flag_Shift,      Hotkey_Flag_LShift,     Hotkey_Flag_RShift,
     Hotkey_Flag_Cmd,        Hotkey_Flag_LCmd,       Hotkey_Flag_RCmd,
     Hotkey_Flag_Control,    Hotkey_Flag_LControl,   Hotkey_Flag_RControl,
-    Hotkey_Flag_Fn,         Hotkey_Flag_Hyper,      Hotkey_Flag_Meh,
+    Hotkey_Flag_Fn,         Hotkey_Flag_Hyper,      Hotkey_Flag_LHyper,
+    Hotkey_Flag_RHyper,     Hotkey_Flag_Meh,
 };
 
 internal uint32_t

--- a/src/tokenize.h
+++ b/src/tokenize.h
@@ -9,7 +9,8 @@ global const char *modifier_flags_str[] =
     "shift", "lshift",  "rshift",
     "cmd",   "lcmd",    "rcmd",
     "ctrl",  "lctrl",   "rctrl",
-    "fn",    "hyper",   "meh",
+    "fn",    "hyper",   "lhyper",
+    "rhyper","meh",
 };
 
 global const char *literal_keycode_str[] =


### PR DESCRIPTION
In some cases it is useful to specify which side the hyper key uses. This allows for some fun key bindings where you can bind lhyper + rshift for example