### PR TITLE
clarification of secure keyboard entry disabling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The first time **skhd** is ran, it will request access to the accessibility API.
 After access has been granted, the application must be restarted.
 
 *Secure Keyboard Entry* must be disabled for **skhd** to receive key-events.
+ * Ensure that it is disable for *all* applications (default Terminal application as well as iTerm, Alacritty etc.)
 
 **Homebrew**:
 


### PR DESCRIPTION
many people are having issues where secure keyboard entry being enabled in more than one application makes it so that skhd 'randomly' stops working and this should clarify the issue.