### PR TITLE
implement key and modifier alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,25 @@ command  = command is executed through '$SHELL -c' and
            an EOL character signifies the end of the bind.
 ```
 
+Aliases can also be used anywhere a modifier or a key is expected:
+```
+# alias as modifier
+.alias $hyper cmd + alt + ctrl
+$hyper - t : open -a Terminal.app
+
+# alias as key
+.alias $capslock 0x39
+ctrl - $capslock : open -a Notes.app
+
+# alias as mod-key
+.alias $exclamation_mark shift - 1
+$hyper - $exclamation_mark : open -a "System Preferences.app"
+
+# alias within alias
+.alias $terminal_key $hyper + shift - t
+$terminal_key : open -a Terminal.app
+```
+
 General options that configure the behaviour of **skhd**:
 ```
 # specify a file that should be included as an additional config-file.

--- a/examples/skhdrc
+++ b/examples/skhdrc
@@ -113,3 +113,22 @@ cmd + shift - return : ~/Scripts/qtb.sh
 
 # open mpv
 cmd - m : open -na /Applications/mpv.app $(pbpaste)
+
+###################
+#  using aliases
+
+# alias as modifier
+.alias $hyper cmd + alt + ctrl
+$hyper - t : open -a Terminal.app
+
+# alias as key
+.alias $capslock 0x39
+ctrl - $capslock : open -a Notes.app
+
+# alias as mod-key
+.alias $exclamation_mark shift - 1
+$hyper - $exclamation_mark : open -a "System Preferences.app"
+
+# alias within alias
+.alias $terminal_key $hyper + shift - t
+$terminal_key : open -a Terminal.app

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -88,17 +88,27 @@ void *table_find(struct table *table, void *key)
     return bucket ? bucket->value : NULL;
 }
 
-void table_add(struct table *table, void *key, void *value)
+void table_newkeyvalue(struct table *table, void *key, void *value, bool do_replace)
 {
     struct bucket **bucket = table_get_bucket(table, key);
     if (*bucket) {
-        if (!(*bucket)->value) {
+        if (do_replace || !(*bucket)->value) {
             (*bucket)->value = value;
         }
     } else {
         *bucket = table_new_bucket(key, value);
         ++table->count;
     }
+}
+
+void table_add(struct table *table, void *key, void *value)
+{
+    table_newkeyvalue(table, key, value, false);
+}
+
+void table_replace(struct table *table, void *key, void *value)
+{
+    table_newkeyvalue(table, key, value, true);
 }
 
 void *table_remove(struct table *table, void *key)

--- a/src/hotkey.c
+++ b/src/hotkey.c
@@ -219,10 +219,8 @@ next:;
         free(mode);
     }
 
-    if (mode_count) {
-        free(modes);
-        buf_free(freed_pointers);
-    }
+    free(modes);
+    buf_free(freed_pointers);
 }
 
 void free_blacklist(struct table *blacklst)
@@ -230,9 +228,21 @@ void free_blacklist(struct table *blacklst)
     int count;
     void **items = table_reset(blacklst, &count);
     for (int index = 0; index < count; ++index) {
-        char *item = (char *) items[index];
-        free(item);
+        free(items[index]);
     }
+
+    free(items);
+}
+
+void free_alias_map(struct table *alias_map)
+{
+    int count;
+    void **items = table_reset(alias_map, &count);
+    for (int index = 0; index < count; ++index) {
+        free(items[index]);
+    }
+
+    free(items);
 }
 
 static void

--- a/src/hotkey.h
+++ b/src/hotkey.h
@@ -43,6 +43,7 @@ enum hotkey_flag
     Hotkey_Flag_LControl    = (1 << 10),
     Hotkey_Flag_RControl    = (1 << 11),
     Hotkey_Flag_Fn          = (1 << 12),
+    Hotkey_Flag_Modifier    = ((Hotkey_Flag_Fn << 1) - 1),
     Hotkey_Flag_Passthrough = (1 << 13),
     Hotkey_Flag_Activate    = (1 << 14),
     Hotkey_Flag_NX          = (1 << 15),
@@ -109,6 +110,7 @@ bool intercept_systemkey(CGEventRef event, struct hotkey *eventkey);
 bool find_and_exec_hotkey(struct hotkey *k, struct table *t, struct mode **m, struct carbon_event *carbon);
 void free_mode_map(struct table *mode_map);
 void free_blacklist(struct table *blacklst);
+void free_alias_map(struct table *alias_map);
 
 void init_shell(void);
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -2,6 +2,7 @@
 #define SKHD_PARSE_H
 
 #include "tokenize.h"
+#include "hotkey.h"
 #include <stdbool.h>
 
 struct load_directive
@@ -19,12 +20,13 @@ struct parser
     struct tokenizer tokenizer;
     struct table *mode_map;
     struct table *blacklst;
+    struct table *alias_map;
     struct load_directive *load_directives;
     bool error;
 };
 
 bool parse_config(struct parser *parser);
-struct hotkey *parse_keypress(struct parser *parser);
+bool parse_keypress(struct parser *parser, struct hotkey *hotkey, bool allow_no_keycode);
 
 struct token parser_peek(struct parser *parser);
 struct token parser_previous(struct parser *parser);
@@ -32,7 +34,7 @@ bool parser_eof(struct parser *parser);
 struct token parser_advance(struct parser *parser);
 bool parser_check(struct parser *parser, enum token_type type);
 bool parser_match(struct parser *parser, enum token_type type);
-bool parser_init(struct parser *parser, struct table *mode_map, struct table *blacklst, char *file);
+bool parser_init(struct parser *parser, struct table *mode_map, struct table *blacklst, struct table * alias_map, char *file);
 bool parser_init_text(struct parser *parser, char *text);
 void parser_destroy(struct parser *parser);
 void parser_report_error(struct parser *parser, struct token token, const char *format, ...);

--- a/src/synthesize.h
+++ b/src/synthesize.h
@@ -1,7 +1,7 @@
 #ifndef SKHD_SYNTHESIZE_H
 #define SKHD_SYNTHESIZE_H
 
-void synthesize_key(char *key_string);
+bool synthesize_key(char *key_string);
 void synthesize_text(char *text);
 
 #endif

--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -218,6 +218,15 @@ get_token(struct tokenizer *tokenizer)
             token.type = Token_Command;
         }
     } break;
+    case '$': {
+        token.text = tokenizer->at;
+        token.line = tokenizer->line;
+        token.cursor = tokenizer->cursor;
+
+        eat_identifier(tokenizer);
+        token.length = tokenizer->at - token.text;
+        token.type = Token_Alias;
+    } break;
     default:  {
         if (c == '0' && *tokenizer->at == 'x') {
             advance(tokenizer);

--- a/src/tokenize.h
+++ b/src/tokenize.h
@@ -57,6 +57,8 @@ enum token_type
     Token_BeginList,
     Token_EndList,
 
+    Token_Alias,
+
     Token_Unknown,
     Token_EndOfStream,
 };


### PR DESCRIPTION
Fixes #174 #6 #280 #226 #194

looks like this: 
```
.alias $hyper cmd + alt + ctrl
.alias $capslock 0x39
.alias $exclamation_mark shift - 1
.alias $terminal_key $hyper + shift - t

# alias as modifier
$hyper - t : open -a Terminal.app

# alias as key
ctrl - $capslock : open -a Notes.app

# alias as mod-key
$hyper - $exclamation_mark : open -a "System Preferences.app"

# alias within alias
$terminal_key : open -a Terminal.app
```

Simplifying keymaps with eg. `hyper` keys. Easier to manage configuration.

This PR also:
 - fixed some memory leaks
 -  reduced code duplication (`parse_hotkey` and `parse_keypress`.)
 -  made `skhd -k` exit with -1 when failed to parse.
 - made `skhd --verbose -k` respect `--verbose` (do not close stdout/stderr when in verbose)

This new feature technically deprecates some keycode literals like `meh` and `hyper`, however they're still kept for backward compatibility.
