### PR TITLE
use xcrun to run Apple clang

### DIFF
--- a/makefile
+++ b/makefile
@@ -16,4 +16,4 @@ clean:
 
 $(BUILD_PATH)/skhd: $(SKHD_SRC)
 	mkdir -p $(BUILD_PATH)
-	clang $^ $(BUILD_FLAGS) $(FRAMEWORKS) -o $@
+	xcrun clang $^ $(BUILD_FLAGS) $(FRAMEWORKS) -o $@


### PR DESCRIPTION
I've installed LLVM's clang on my machine and it has higher priority than Apple's clang in shell's PATH. When I run `make` it would produce following errors:
```
clang src/skhd.c -std=c99 -Wall -g -O0 -framework Cocoa -framework Carbon -framework CoreServices -o bin/skhd
In file included from src/skhd.c:30:
src/service.h:136:9: error: call to undeclared function '_NSGetExecutablePath'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    if (_NSGetExecutablePath(exe_path, &exe_path_size) < 0) {
```

After I force it to use Apple's clang then the error is gone.